### PR TITLE
deps: upgrade oracle residual testcontainers package

### DIFF
--- a/tests/integration/Syrx.Oracle.Tests.Integration/Syrx.Oracle.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Oracle.Tests.Integration/Syrx.Oracle.Tests.Integration.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />    
-    <PackageReference Include="Testcontainers.Oracle" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.Oracle" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates the `Testcontainers.Oracle` package to the latest version in the integration test project. This is a minor dependency upgrade and should not affect existing functionality unless there are breaking changes in the new package version.

Dependency updates:

* Upgraded `Testcontainers.Oracle` from version `4.11.0` to `4.12.0` in `Syrx.Oracle.Tests.Integration.csproj`.